### PR TITLE
explicit 'over' dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "async": "0.1.15",
-    "over": "git://github.com/nearinfinity/node-over.git",
+    "over": ">=0.0.5",
     "db-info": "0.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Disable downloading 'over' from github. 
There is same problems to 'git clone' on Windows systems.
