### PR TITLE
`TypeError: Cannot read property 'trace' of undefined`

### DIFF
--- a/lib/drivers/mysql.js
+++ b/lib/drivers/mysql.js
@@ -94,7 +94,7 @@ var MySqlDriver = Driver.extend({
       callback(null, conn);
     } else {
       var db = new mysql.createClient(opts);
-      conn = new MySqlConnection(this, db, true);
+      conn = new MySqlConnection(this, db, true, opts);
       callback(null, conn);
     }
   }


### PR DESCRIPTION
I got a `TypeError: Cannot read property 'trace' of undefined` ([here](https://github.com/nearinfinity/node-persist/blob/fcad293b64035d7779798a52865b52aa1a4bbdc4/lib/connection.js#L428)) when allowing the `MySqlDriver` to create the connection. Said driver doesn't pass the options to the connection.
