### PR TITLE
Switch to official sqlite3 package

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "nodeunit": "~>0.6.4",
-    "sqlite3": "git://github.com/joeferner/node-sqlite3.git"
+    "sqlite3": "~>2.1.7"
   },
   "scripts": {
     "test": "nodeunit test"


### PR DESCRIPTION
The old sqlite3 package specified in `package.json` pointed to https://github.com/joeferner/node-sqlite3, which fails to build in Windows XP. The official repository, https://github.com/developmentseed/node-sqlite3, does build well in Windows XP, resulting in a happier OS-agnostic environment for node-persist. Also, the official sqlite3 repo was updated a month ago, while the old fork we were using in our `package.json` is nearly a year out of date.

I ran `npm install && npm test`, and got `OK: 219 assertions (1313ms)`. :)
