### PR TITLE
Configured for jshint

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,3 @@
+node_modules
+*.min.js
+*-min.js

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,5 @@
+{
+  "es5": true,
+  "expr": true,
+  "-W092": false
+}


### PR DESCRIPTION
Followed the `.jshintrc` used by [node-db-migrate](https://github.com/nearinfinity/node-db-migrate/blob/master/.jshintrc).
