### PR TITLE
mysql transactions shouldn't set autocommit flag before running

### DIFF
--- a/lib/drivers/mysql.js
+++ b/lib/drivers/mysql.js
@@ -18,7 +18,7 @@ var MySqlConnection = Connection.extend({
   },
 
   beginTransaction: function (callback) {
-    this._runSql(["SET autocommit=0", "START TRANSACTION"], callback);
+    this._runSql("START TRANSACTION", callback);
   },
 
   commitTransaction: function (callback) {


### PR DESCRIPTION
its done implicitly by calling `START TRANSACTION`. running `SET autocommit=0` causes every db statement afterwards to not use autocommit, since calling `ROLLBACK`  restores the autocommit flag to what it previously was (as opposed to setting the autocommit flag back to 1). 
