### PR TITLE
Fix so that multiple hasOne with the same model can be included

### DIFF
--- a/lib/sqltree.js
+++ b/lib/sqltree.js
@@ -68,15 +68,18 @@ var SqlTree = Class.extend({
     return null;
   },
 
-  populateInclude: function (result, item, include) {
-    var i;
+  populateInclude: function (result, item, include, start_col, end_col) {
+    var i,j;
     var includeItems = [];
     if (!include.primaryKeyColumn) {
       throw new Error('Include "' + include.propertyName + '" does not have a single primary key defined.');
     }
     var groups = persistUtil.groupBy(item, include.primaryKeyColumn.alias);
     for (i = 0; i < groups.length; i++) {
-      var includeItem = groups[i][0];
+      var includeItem = {}; 
+      // only include the columns that belongs to this include
+      for(j = start_col; j < end_col; j++) 
+        includeItem['c'+j] = groups[i][0]['c'+j];
       var includeItemInstance = new include.association.model();
       includeItemInstance = this.toObject(includeItem, includeItemInstance);
 
@@ -93,11 +96,14 @@ var SqlTree = Class.extend({
     }
   },
 
-  populateIncludes: function (result, item) {
+  populateIncludes: function (result, item, start_col) {
     var i;
+    var end_col;
     for (i = 0; i < this.includes.length; i++) {
       var include = this.includes[i];
-      this.populateInclude(result, item, include);
+      end_col = Number(include.primaryKeyColumn.alias.substring(1))+1;
+      this.populateInclude(result, item, include, start_col, end_col);
+      start_col = end_col;
     }
   },
 
@@ -117,7 +123,7 @@ var SqlTree = Class.extend({
         result = this.toObject(item[0], result);
         results.push(result);
 
-        this.populateIncludes(result, item);
+        this.populateIncludes(result, item, Number(this.primaryKeyColumn.alias.substring(1))+1);
       }
       return results;
     }


### PR DESCRIPTION
This fixes (in a crude way) a problem that occurs when you have multiple hasOne relations that references the same model. For example:

 module.exports = Calibration = persist.define("Calibration", {
   "created_at": { type: type.DATETIME, defaultValue: function() { return new Date() } },
   "m0": { type: type.INTEGER },
   "m1": { type: type.INTEGER },
    "m2": { type: type.INTEGER },
   "m3": { type: type.INTEGER }
})
.hasOne(Measurement, { foreignKey: 'm0', name: "vol0", createHasMany: false })
.hasOne(Measurement, { foreignKey: 'm1', name: "vol1", createHasMany: false })
.hasOne(Measurement, { foreignKey: 'm2', name: "vol2", createHasMany: false })
.hasOne(Measurement, { foreignKey: 'm3', name: "vol3", createHasMany: false });

Calibration.orderBy('id').limit(5, 0).include(['vol0', 'vol1', 'vol2', 'vol3']).all(connection, function(err, calibrations) { }

would return measurement model vol3 for vol0, vol1, and vol2.

The fix in this pull request is not ideal (it only works if the columns are ordered and named the same way) but it fixes the problem.
It could perhaps help finding a proper solution to this, i would guess the problem would be better fixed in the groupBy function.
