### PR TITLE
fix query with multiple parameters with postgresql

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -254,7 +254,7 @@ var Driver = Class.extend({
       var item = sqlTree.where[i];
       var expr = item.expr;
       expr = this.propertyNamesToColumnNames(sqlTree, item.expr, aliasTables);
-      expr = expr.replace(/\?/, getValuesSubstitutionStringFunc);
+      expr = expr.replace(/\?/g, getValuesSubstitutionStringFunc);
       expressions.push(expr);
       values = values.concat(item.params);
     }


### PR DESCRIPTION
Hi, I found a problem while doing queries with multiple parameters in postgresql, the query builder didn't replace all question marks with the corresponding code. I think it's only the matter of using the global setting for the regexp.
tested with postgresql and sqlite3
