### PR TITLE
Fixed ignored connection errors for mysql alpha 2.0 driver

### DIFF
--- a/lib/drivers/mysql.js
+++ b/lib/drivers/mysql.js
@@ -100,11 +100,12 @@ var MySqlDriver = Driver.extend({
         callback(null, conn);
       } else {
         db = new mysql.createConnection(opts);
+        var _this = this;
         db.connect(function(err) {
           if (err) {
             callback(err);
           } else {
-            conn = new MySqlConnection(this, db, true, opts);
+            conn = new MySqlConnection(_this, db, true, opts);
             callback(null, conn);
           }
         });


### PR DESCRIPTION
I found following bug. It applies to alpha 2.0 node-mysql version. I also used connection pools (didn't check if problem exists without them). 
When calling connect on persist object I never get errors even if database is not responding. There is synchronous  connection creation in your code while proper way is to pass a callback. In fact callback is passed but only for logging purposes. I'm not sure this fix won't break anything but it seems to fix my problem.
