### PR TITLE
Prevent Model.normalizeColumnDef to underscore columnName.

### DIFF
--- a/lib/persist.js
+++ b/lib/persist.js
@@ -32,6 +32,9 @@ exports.defineAuto = function(name, options, callback) {
   this.asyncQueue().push(options, function(err, result) {
     if (result.tables.hasOwnProperty(pluralName)) {
       var columnDefs = result.tables[pluralName].columns;
+      for (var propertyName in columnDefs) {
+        columnDefs[propertyName].dbColumnName = propertyName;
+      }
       var model = Model.define(name, columnDefs);
       callback(null, model);
     }


### PR DESCRIPTION
If a table has a column ID, it is mapped to "i_d".
